### PR TITLE
CLI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,137 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+*.ipynb
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# data
+.DS_Store
+*.csv
+*.sql
+*.pickle
+metadata/

--- a/getGrantsData.py
+++ b/getGrantsData.py
@@ -4,8 +4,6 @@ import requests
 import pandas as pd
 import sys
 
-from hypercerts import get_metadata
-
 # Gitcoin Round Manager subgraph ID on The Graph
 SUBGRAPH = "BQXTJRLZi7NWGq5AXzQQxvYNa5i1HmqALEJwy3gGJHCr"
 ROUNDS = {
@@ -119,7 +117,6 @@ def main(round_id, api_key):
     df['ipfs_data'] = df['pointer'].apply(retrieve_ipfs_file)
     df['recipient'] = df['ipfs_data'].apply(lambda x: x["application"]["recipient"])
     df['title'] = df['ipfs_data'].apply(lambda x: x["application"]["project"]["title"])
-    df['hypercert'] = df['ipfs_data'].apply(get_metadata)
    
     #Construct names for files that will be saved
     csv_file_name = '{}_{}_data.csv'.format(current_time, id)

--- a/getGrantsData.py
+++ b/getGrantsData.py
@@ -24,7 +24,7 @@ def get_round_data(round_id, api_key):
         id: "''' + round_id + '''"
     }) {
         id
-        projects {
+        projects(first:300) {
         id
         project
         status


### PR DESCRIPTION
1. Store the IPFS metadata in the outfiles
2. Made some updates so the script can be called from the command line by passing your `API key` and a `round name` as variables. 

For example: `python getGrantsData.py MY_API_KEY eth_infra`

Rounds are mapped as follows:
```
ROUNDS = {
    'climate': '0x1b165fe4da6bc58ab8370ddc763d367d29f50ef0', 
    'oss': '0xd95a1969c41112cee9a2c931e849bcef36a16f4c', 
    'eth_infra': '0xe575282b376e3c9886779a841a2510f1dd8c2ce4'
}
```